### PR TITLE
Small changes to the "event section" - images are now fully visible

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -2,7 +2,7 @@
 	margin: 0;
 	padding: 0;
 	box-sizing: border-box;
-	cursor: default;
+	cursor: none; 
 }
 
 html{

--- a/src/styles.css
+++ b/src/styles.css
@@ -215,7 +215,8 @@ nav ul li a:hover::after{
 	left:0;
 	height:100%;
     width: 80%; /*reduced the width, more responsive*/
-    background-attachment: fixed;
+	background-attachment: fixed;
+	padding: 1% 0;
 }
 #myCarousel h4{
 	font-size:50px;
@@ -401,7 +402,8 @@ nav ul li a:hover::after{
 	text-align: center;
 	font-weight: 300;
 	-webkit-font-smoothing: antialiased;
-	padding-top: 4%;
+	padding-top: 1%;
+	margin-top: 2%;
   }
 #contact-form {
 	max-width: 90%;

--- a/src/styles.css
+++ b/src/styles.css
@@ -214,7 +214,7 @@ nav ul li a:hover::after{
     top: 0;
 	left:0;
 	height:100%;
-    width: 100%;
+    width: 80%; /*reduced the width, more responsive*/
     background-attachment: fixed;
 }
 #myCarousel h4{
@@ -236,7 +236,7 @@ nav ul li a:hover::after{
 #myCarousel .carousel-item h4{-webkit-animation-name:fadeInLeft; animation-name:fadeInLeft;} 
 #myCarousel .carousel-item p{-webkit-animation-name:slideInRight; animation-name:slideInRight;} 
 #myCarousel .carousel-item a{-webkit-animation-name:fadeInUp; animation-name:fadeInUp;}
-#myCarousel .carousel-item .mask img{-webkit-animation-name:slideInRight; animation-name:slideInRight; display:block;height: 100%; max-width: 470px; min-width: 200px;}
+#myCarousel .carousel-item .mask img{-webkit-animation-name:slideInRight; animation-name:slideInRight; display:block; width: 67vh;}
 #myCarousel h4, #myCarousel p, #myCarousel a, #myCarousel .carousel-item .mask img{
 	-webkit-animation-duration: 1s;
     animation-duration: 1.2s;

--- a/src/styles.css
+++ b/src/styles.css
@@ -401,6 +401,7 @@ nav ul li a:hover::after{
 	text-align: center;
 	font-weight: 300;
 	-webkit-font-smoothing: antialiased;
+	padding-top: 4%;
   }
 #contact-form {
 	max-width: 90%;

--- a/src/styles.css
+++ b/src/styles.css
@@ -2,7 +2,7 @@
 	margin: 0;
 	padding: 0;
 	box-sizing: border-box;
-	cursor: none;
+	cursor: default;
 }
 
 html{
@@ -216,7 +216,8 @@ nav ul li a:hover::after{
 /* Events Section */
 
 #myCarousel .carousel-item .mask {
-    position: absolute;
+	/* The carousel container takes now all the height of the leaflet by removing the absolute position */
+    /* position: absolute; */
     top: 0;
 	left:0;
 	height:100%;

--- a/src/styles.css
+++ b/src/styles.css
@@ -169,10 +169,6 @@ nav ul li a:hover::after{
 
 /* Events Section Styling */
 
-#events , #quiz{
-	height: 100vh;
-}
-
 .heading{
 	width: fit-content;
 	margin: 20px auto;
@@ -194,9 +190,6 @@ nav ul li a:hover::after{
 
 /* Section Styling */
 
-#quiz, #events{
-	height: 100vh;
-}
 
 .heading{
 	width: fit-content;


### PR DESCRIPTION
Hi All,
I made a few changes to the website to make it more user-friendly.
Now it is possible to see the leaflets in full. I obtained this by removing the absolute position and reducing the width of the .mask and of the pictures
```diff
#myCarousel .carousel-item .mask {
- position: absolute;
- width: 100%;
+ width: 80%;
+ padding: 1% 0;
}
```

Let me know if you like the final result or if there something else you would like me to work on.